### PR TITLE
Version 0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.5]
+### Added
+ * custom error type.
+ * more tests.
+ * `request_api::Hexbot.colors()`.
+ * support for the count parameter of hexbot.
+
+### Changed
+ * output of `fmt::Display` for Hexbot.
+ * `request_api::fetch()`
+   * old: `request_api::fetch() -> Result<Hexbot, reqwest::Error>`
+   * new: `request_api::fetch(count: i32) -> Result<Hexbot, Error>`
+
+### Removed
+ * `request_api::Hexbot.color()`.
+
 ## [0.0.4]
 ### Added
  * documentation & hacking.
@@ -31,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Support for requesting, parsing and printing a hexbot request without parameters.
  - All stuff around a project like README, LICENSE, .gitignore, ...
 
+[0.0.5]: https://github.com/rusty-snake/hexbot/tree/v0.0.5
 [0.0.4]: https://github.com/rusty-snake/hexbot/tree/v0.0.4
 [0.0.3]: https://github.com/rusty-snake/hexbot/tree/v0.0.3
 [0.0.2]: https://github.com/rusty-snake/hexbot/tree/v0.0.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "hexbot"
-version = "0.0.4"
+version = "0.0.5-dev"
 dependencies = [
  "reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -717,7 +717,7 @@ dependencies = [
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -878,19 +878,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1492,8 +1492,8 @@ dependencies = [
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
-"checksum regex 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1325e8a57b7da4cbcb38b3957112f729990bad0a18420e7e250ef6b1d9a15763"
-"checksum regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d76410686f9e3a17f06128962e0ecc5755870bb890c34820c7af7f1db2e1d48"
+"checksum regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "d9d8297cc20bbb6184f8b45ff61c8ee6a9ac56c156cec8e38c3e5084773c44ad"
+"checksum regex-syntax 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "9b01330cce219c1c6b2e209e5ed64ccd587ae5c67bed91c0b49eecf02ae40e21"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)" = "00eb63f212df0e358b427f0f40aa13aaea010b470be642ad422bcbca2feff2e4"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "hexbot"
-version = "0.0.5-dev"
+version = "0.0.5"
 dependencies = [
  "reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ license = "GPL-3.0-or-later"
 reqwest = "0.9.18"
 serde = { version = "1.0", default_features = false, features = ["derive"] }
 tint = "1.0.1"
+
+[features]
+# description() is deprecated; use Display
+ErrorDescription = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hexbot"
 description = "My solution for: https://noopschallenge.com/challenges/hexbot"
-version = "0.0.4"
+version = "0.0.5-dev"
 authors = ["rusty-snake <print_hello_world+Public@protonmail.com>"]
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hexbot"
 description = "My solution for: https://noopschallenge.com/challenges/hexbot"
-version = "0.0.5-dev"
+version = "0.0.5"
 authors = ["rusty-snake <print_hello_world+Public@protonmail.com>"]
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ copy [`src/request_api.rs`](src/request_api.rs) into `src/request_api.rs` in you
 reqwest = "0.9.18"
 serde = { version = "1.0", default_features = false, features = ["derive"] }
 tint = "1.0.1"
+
+[features]
+ErrorDescription = []
 ```
 
 `src/main.rs`:

--- a/README.md
+++ b/README.md
@@ -92,10 +92,19 @@ For the next steps, see the documentation.
 ```markdown
 ## [0.0.5]
 ### Added
+ * custom error type.
+ * more tests.
+ * `request_api::Hexbot.colors()`.
+ * support for the count parameter of hexbot.
 
 ### Changed
+ * output of `fmt::Display` for Hexbot.
+ * `request_api::fetch()`
+   * old: `request_api::fetch() -> Result<Hexbot, reqwest::Error>`
+   * new: `request_api::fetch(count: i32) -> Result<Hexbot, Error>`
 
 ### Removed
+ * `request_api::Hexbot.color()`.
 
 [0.0.5]: https://github.com/rusty-snake/hexbot/tree/v0.0.5
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hexbot :construction: <br> [![top lang]][rust] ![rust 2018] ![rustc 1.31+] [![GPLv3+]][COPYING] [![version]][tag]
+# Hexbot :construction: <br> [![top lang]][rust] ![rust 2018] ![rustc 1.31+] [![GPLv3+]][COPYING] ![version]
 
 [top lang]: https://img.shields.io/github/languages/top/rusty-snake/hexbot.svg?logo=rust
 [rust]: https://www.rust-lang.org/
@@ -6,13 +6,10 @@
 [rust 2018]: https://img.shields.io/badge/rust--edition-2018-blue.svg
 [GPLv3+]: https://img.shields.io/github/license/rusty-snake/hexbot.svg?color=darkred
 [COPYING]: COPYING
-[version]: https://img.shields.io/github/tag/rusty-snake/hexbot.svg?label=version
-[tag]: https://github.com/rusty-snake/hexbot/tree/v0.0.3
+[version]: https://img.shields.io/github/tag/rusty-snake/hexbot.svg?label=lastet%20release
 
 <!--![GitHub open issues](https://img.shields.io/github/issues/rusty-snake/hexbot.svg)-->
 <!--![GitHub closed issues](https://img.shields.io/github/issues-closed/rusty-snake/hexbot.svg)-->
-<!--![GitHub open pull requests](https://img.shields.io/github/issues-pr/rusty-snake/hexbot.svg)-->
-<!--![GitHub language count](https://img.shields.io/github/languages/count/rusty-snake/hexbot.svg)-->
 <!--![GitHub commit activity](https://img.shields.io/github/commit-activity/w/rusty-snake/hexbot.svg)-->
 
 My solution for: https://noopschallenge.com/challenges/hexbot
@@ -48,10 +45,10 @@ Should not be necessary because new features are created in separate branches an
 $ cargo run --release
     Updating crates.io index
    ...
-   Compiling hexbot v0.0.4 (/home/rusty-snake/hexbot)
-    Finished release [optimized] target(s) in 8m 5s
+   Compiling hexbot v0.0.5 (/home/rusty-snake/hexbot)
+    Finished release [optimized] target(s) in 4m 2s
      Running `target/release/hexbot`
-Hexbot responded with color #F1FF64.
+Hexbot responded with this colors [#69B4F4, #170313, #5AC9A6].
 ```
 
 #### Compile only
@@ -93,17 +90,14 @@ For the next steps, see the documentation.
 ## Changelog
 
 ```markdown
-## [0.0.4]
+## [0.0.5]
 ### Added
- * documentation & hacking.
 
 ### Changed
- * Function names:
-   * `get_color()` -> `color()`
-   * `get_hexbot()` -> `fetch()`
- * Use `tint::Color` instead of `String` for colors.
 
-[0.0.4]: https://github.com/rusty-snake/hexbot/tree/v0.0.4
+### Removed
+
+[0.0.5]: https://github.com/rusty-snake/hexbot/tree/v0.0.5
 ```
 
 For the full Changelog see [CHANGELOG.md](CHANGELOG.md).

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,9 @@
 // needs pub to generate documentation.
 pub mod request_api;
 
-fn main() {
-    let hexbot = request_api::fetch().unwrap();
-    println!("Hexbot responded with color {}.", hexbot);
+fn main() -> Result<(), request_api::Error> {
+    let hexbot = request_api::fetch(3)?;
+    println!("Hexbot responded with this colors {}.", hexbot);
+
+    Ok(())
 }

--- a/src/request_api.rs
+++ b/src/request_api.rs
@@ -44,8 +44,8 @@ use tint::Color;
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
 struct Dot {
-    #[serde(deserialize_with = "deserialize_color")]
-    value: Color,
+    #[serde(deserialize_with = "deserialize_color", rename = "value")]
+    color: Color,
 }
 
 /// Deserialized response.
@@ -63,13 +63,13 @@ impl Hexbot {
     ///
     /// [documentation]: https://docs.rs/tint/1.0.1/tint/struct.Color.html
     pub fn color(&self) -> &Color {
-        &self.colors[0].value
+        &self.colors[0].color
     }
 }
 
 impl fmt::Display for Hexbot {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.colors[0].value.to_hex().to_uppercase())
+        write!(f, "{}", self.colors[0].color.to_hex().to_uppercase())
     }
 }
 
@@ -89,7 +89,7 @@ mod tests {
     #[test]
     fn test_get_color() {
         let color = Dot {
-            value: Color::new(1.0, 1.0, 1.0, 1.0),
+            color: Color::new(1.0, 1.0, 1.0, 1.0),
         };
         let hexbot = Hexbot { colors: [color; 1] };
 

--- a/src/request_api.rs
+++ b/src/request_api.rs
@@ -169,4 +169,29 @@ mod tests {
             ]
         );
     }
+
+    #[test]
+    fn test_fetch_count_out_of_range() {
+        assert!(match fetch(-1) {
+            Err(Error::CountOutOfRange) => true,
+            _ => false,
+        });
+        assert!(match fetch(0) {
+            Err(Error::CountOutOfRange) => true,
+            _ => false,
+        });
+        assert!(match fetch(1001) {
+            Err(Error::CountOutOfRange) => true,
+            _ => false,
+        });
+    }
+
+    #[test]
+    #[ignore]
+    fn test_fetch() {
+        let mut hb = fetch(3).unwrap();
+        assert_eq!(hb.colors.len(), 3);
+        hb.colors = vec![];
+        assert_eq!(hb, Hexbot { colors: vec![] });
+    }
 }


### PR DESCRIPTION
 ## [0.0.5]
 ### Added
  * custom error type.
  * more tests.
  * `request_api::Hexbot.colors()`.
  * support for the count parameter of hexbot.

 ### Changed
  * output of `fmt::Display` for Hexbot.
  * `request_api::fetch()`
    * old: `request_api::fetch() -> Result<Hexbot, reqwest::Error>`
    * new: `request_api::fetch(count: i32) -> Result<Hexbot, Error>`

 ### Removed
  * `request_api::Hexbot.color()`.

 [0.0.5]: https://github.com/rusty-snake/hexbot/tree/v0.0.5