### PR TITLE
v0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
  * `Seed::add`
+ * impl ops::{Add,Sub} for Coordinates
 
 ## [0.0.10] - 2019-09-28
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  * `Seed::add`
  * impl ops::{Add,Sub} for Coordinates
+ * `hexbot::WidthHeight` improved replacement for `WithCoordinates` and `CoordinatesLimit`
 
 ## [0.0.10] - 2019-09-28
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * impl ops::{Add,Sub} for Coordinates
  * `hexbot::WidthHeight` improved replacement for `WithCoordinates` and `CoordinatesLimit`
 
+### Changed
+ * `Hexbot::fetch` accept both `WithCoordinates` and `WidthHeight`
+
+### Deprecated
+ * `WithCoordinates` use `WidthHeight`
+ * `CoordinatesLimit` use `WidthHeight`
+
 ## [0.0.10] - 2019-09-28
 ### Changed
  * min rustc: 1.37.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+ * `Seed::add`
+
 ## [0.0.10] - 2019-09-28
 ### Changed
  * min rustc: 1.37.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.0.11] - 2019-10-13
 ### Added
  * `Seed::add`
  * impl ops::{Add,Sub} for Coordinates
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  * `Hexbot::fetch` accept both `WithCoordinates` and `WidthHeight`
+ * old:`SeedError::NoColor` new:`SeedError::NoColor(i32)`
 
 ### Deprecated
  * `WithCoordinates` use `WidthHeight`
@@ -108,6 +109,7 @@ maintenance release
  - Support for requesting, parsing and printing a hexbot request without parameters.
  - All stuff around a project like README, LICENSE, .gitignore, ...
 
+[0.0.11]: https://github.com/rusty-snake/hexbot/tree/v0.0.11
 [0.0.10]: https://github.com/rusty-snake/hexbot/tree/v0.0.10
 [0.0.9]: https://github.com/rusty-snake/hexbot/tree/v0.0.9
 [0.0.8]: https://github.com/rusty-snake/hexbot/tree/v0.0.8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "hexbot"
-version = "0.0.11-dev"
+version = "0.0.11"
 dependencies = [
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "hexbot"
-version = "0.0.10"
+version = "0.0.11-dev"
 dependencies = [
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hexbot"
-version = "0.0.10"
+version = "0.0.11-dev"
 description = "My solution for: https://noopschallenge.com/challenges/hexbot"
 authors = ["rusty-snake <print_hello_world+Public@protonmail.com>"]
 repository = "https://github.com/rusty-snake/hexbot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hexbot"
-version = "0.0.11-dev"
+version = "0.0.11"
 description = "My solution for: https://noopschallenge.com/challenges/hexbot"
 authors = ["rusty-snake <print_hello_world+Public@protonmail.com>"]
 repository = "https://github.com/rusty-snake/hexbot"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ cd hexbot
 $ cargo run --release
     Updating crates.io index
    ...
-   Compiling hexbot v0.0.10 (/home/rusty-snake/hexbot)
+   Compiling hexbot v0.0.11 (/home/rusty-snake/hexbot)
     Finished release [optimized] target(s) in 4m 2s
      Running `target/release/hexbot`
 ===== Hexbot =====
@@ -82,17 +82,17 @@ Using the hexbot library in your own project.
 `Cargo.toml`:
 ```toml
 [dependencies]
-hexbot = { git = "https://github.com/rusty-snake/hexbot", tag = "v0.0.10" }
+hexbot = { git = "https://github.com/rusty-snake/hexbot", tag = "v0.0.11" }
 ```
 
 `src/main.rs`:
 ```rust
-use hexbot::{Count, Hexbot, Seed, WithCoordinates};
+use hexbot::{Count, Hexbot, Seed, WidthHeight};
 
 fn main() {
     let hb = Hexbot::fetch(
         Count::no(),
-        WithCoordinates::no(),
+        WidthHeight::no(),
         &Seed::no()
     );
     println!("Hello from Hexbot: {}", hb);
@@ -104,18 +104,21 @@ For the next steps, see the [documentation](#documentation).
 ## Changelog
 
 ```markdown
-## [0.0.10] - 2019-09-28
-### Changed
- * min rustc: 1.37.0
-
+## [0.0.11] - 2019-10-13
 ### Added
-  * library to use the hexbot API
+ * `Seed::add`
+ * impl ops::{Add,Sub} for Coordinates
+ * `hexbot::WidthHeight` improved replacement for `WithCoordinates` and `CoordinatesLimit`
 
-### Removed
-  * feature: `ErrorDescription`
-  * `src/request_api.rs`
+### Changed
+ * `Hexbot::fetch` accept both `WithCoordinates` and `WidthHeight`
+ * old:`SeedError::NoColor` new:`SeedError::NoColor(i32)`
 
-[0.0.10]: https://github.com/rusty-snake/hexbot/tree/v0.0.10
+### Deprecated
+ * `WithCoordinates` use `WidthHeight`
+ * `CoordinatesLimit` use `WidthHeight`
+
+[0.0.11]: https://github.com/rusty-snake/hexbot/tree/v0.0.11
 ```
 
 For the full Changelog see [CHANGELOG.md](CHANGELOG.md).

--- a/src/hexbot/coordinates.rs
+++ b/src/hexbot/coordinates.rs
@@ -30,7 +30,7 @@ use std::{fmt, ops};
 /// # use hexbot::*;
 /// let hb = Hexbot::fetch(
 ///     Count::yes(3)?,
-///     WithCoordinates::yes(CoordinatesLimit::min()),
+///     WidthHeight::min(),
 ///     &Seed::no()
 /// )
 /// .expect("Fetching failed");

--- a/src/hexbot/coordinates.rs
+++ b/src/hexbot/coordinates.rs
@@ -18,7 +18,7 @@
  */
 
 use serde::Deserialize;
-use std::fmt;
+use std::{fmt, ops};
 
 /// Generic representation for coordinates with an x and a y value.
 ///
@@ -51,6 +51,20 @@ use std::fmt;
 /// println!("{}!", x + y );
 /// ```
 ///
+/// ```
+/// # use hexbot::Coordinates;
+/// let coordinates1 = Coordinates { x: 15, y: 30 };
+/// let coordinates2 = Coordinates { x: 15, y: 30 };
+/// assert_eq!(
+///     coordinates1 + coordinates2,
+///     Coordinates { x: 30, y: 60 }
+/// );
+/// assert_eq!(
+///     coordinates1 - coordinates2,
+///     Coordinates { x: 0, y: 0 }
+/// );
+/// ```
+///
 /// [`Hexbot`]: struct.Hexbot.html
 /// [`CoordinatesLimit`]: struct.CoordinatesLimit.html
 #[allow(missing_docs)]
@@ -62,5 +76,25 @@ pub struct Coordinates {
 impl fmt::Display for Coordinates {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "({}|{})", self.x, self.y)
+    }
+}
+impl ops::Add for Coordinates {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        Self {
+            x: self.x + other.x,
+            y: self.y + other.y,
+        }
+    }
+}
+impl ops::Sub for Coordinates {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self {
+        Self {
+            x: self.x - other.x,
+            y: self.y - other.y,
+        }
     }
 }

--- a/src/hexbot/coordinateslimit.rs
+++ b/src/hexbot/coordinateslimit.rs
@@ -17,6 +17,8 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+#![deprecated(since = "0.0.11", note = "Use WidthHeight instead.")]
+
 use crate::{errors::CoordinatesLimitOutOfRange, Coordinates};
 use std::{fmt, ops};
 

--- a/src/hexbot/count.rs
+++ b/src/hexbot/count.rs
@@ -29,7 +29,7 @@ use std::{fmt, ops};
 /// // Fetch a Hexbot with 500 colors.
 /// let hb = Hexbot::fetch(
 ///     Count::yes(500)?,
-///     WithCoordinates::no(),
+///     WidthHeight::no(),
 ///     &Seed::no()
 /// )?;
 /// # assert_eq!(hb.len(), 500);
@@ -37,7 +37,7 @@ use std::{fmt, ops};
 /// // Don't add the `count` parameter to the request.
 /// let hb = Hexbot::fetch(
 ///     Count::no(),
-///     WithCoordinates::no(),
+///     WidthHeight::no(),
 ///     &Seed::no()
 /// )?;
 /// # assert_eq!(hb.len(), 1);

--- a/src/hexbot/dot.rs
+++ b/src/hexbot/dot.rs
@@ -51,8 +51,10 @@ use tint::Color;
 /// [API-doc]: https://github.com/noops-challenge/hexbot/blob/master/API.md
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
 pub struct Dot {
+    /// The color (hexbot: value)
     #[serde(rename = "value", deserialize_with = "deserialize_color")]
     pub color: Color,
+    /// The coordinates (if present)
     pub coordinates: Option<Coordinates>,
 }
 impl Dot {

--- a/src/hexbot/dot.rs
+++ b/src/hexbot/dot.rs
@@ -30,7 +30,7 @@ use tint::Color;
 /// # use hexbot::*;
 /// let hb1 = Hexbot::fetch(
 ///     Count::yes(5)?,
-///     WithCoordinates::no(),
+///     WidthHeight::no(),
 ///     &Seed::new(&[0x_B7_41_0E])?
 /// )
 /// .expect("Fetching failed");
@@ -39,7 +39,7 @@ use tint::Color;
 ///
 /// let hb2 = Hexbot::fetch(
 ///     Count::yes(5)?,
-///     WithCoordinates::yes(CoordinatesLimit::new(2500, 4000)?),
+///     WidthHeight::yes(2500, 4000)?,
 ///     &Seed::no()
 /// )
 /// .expect("Fetching failed");
@@ -64,7 +64,7 @@ impl Dot {
     /// # use hexbot::*;
     /// let hexbot_without_coordinates = Hexbot::fetch(
     ///     Count::no(),
-    ///     WithCoordinates::no(),
+    ///     WidthHeight::no(),
     ///     &Seed::no()
     /// )
     /// .expect("Fetching failed");
@@ -73,7 +73,7 @@ impl Dot {
     ///
     /// let hexbot_with_coordinates = Hexbot::fetch(
     ///     Count::no(),
-    ///     WithCoordinates::yes(CoordinatesLimit::new(20, 20)?),
+    ///     WidthHeight::yes(20, 20)?,
     ///     &Seed::no()
     /// )
     /// .expect("Fetching failed");

--- a/src/hexbot/errors.rs
+++ b/src/hexbot/errors.rs
@@ -56,8 +56,7 @@ impl fmt::Display for CoordinatesLimitOutOfRange {
 pub enum SeedError {
     Empty,
     ToLong,
-    /// **This variant will change in the future to `NoColor(i32)`.**
-    NoColor,
+    NoColor(i32),
 }
 impl StdError for SeedError {}
 impl fmt::Display for SeedError {
@@ -65,7 +64,7 @@ impl fmt::Display for SeedError {
         match self {
             Self::Empty => write!(f, "The given seed was an empty slice."),
             Self::ToLong => write!(f, "The given seed had 11 or more colors."),
-            Self::NoColor => write!(f, "A given color wasn't a color."),
+            Self::NoColor(_) => write!(f, "A given color wasn't a color."),
         }
     }
 }

--- a/src/hexbot/hexbot.rs
+++ b/src/hexbot/hexbot.rs
@@ -17,7 +17,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use crate::{Count, Dot, Seed, WithCoordinates};
+use crate::{Count, Dot, Seed, __WidthHeight};
 use serde::Deserialize;
 use std::{
     fmt::{self, Write},
@@ -62,6 +62,9 @@ pub struct Hexbot {
 #[allow(clippy::len_without_is_empty)] // Hexbot.colors should never be empty
 impl Hexbot {
     /// Creates a new instance of `Hexbot`
+    ///
+    /// `coordinates` can be [`WidthHeight`] or [`WithCoordinates`], but you should use
+    /// [`WidthHeight`].
     ///
     /// # Errors
     ///
@@ -109,21 +112,21 @@ impl Hexbot {
     /// )?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    ///
+    /// [`WidthHeight`]: struct.WidthHeight.html
+    /// [`WithCoordinates`]: struct.WithCoordinates.html
     pub fn fetch(
         count: Count,
-        coordinates: WithCoordinates,
+        coordinates: impl __WidthHeight,
         seed: &Seed,
     ) -> Result<Self, reqwest::Error> {
         let count = match count.get() {
             None => String::new(),
             Some(count) => format!("&count={}", count),
         };
-        let coordinates = match coordinates.limit() {
+        let coordinates = match __WidthHeight::get(&coordinates) {
             None => String::new(),
-            Some(coordinates) => {
-                let coordinates = coordinates.get();
-                format!("&width={}&height={}", coordinates.x, coordinates.y)
-            }
+            Some(coordinates) => format!("&width={}&height={}", coordinates.x, coordinates.y),
         };
         let seed = match seed.get() {
             None => String::new(),

--- a/src/hexbot/hexbot.rs
+++ b/src/hexbot/hexbot.rs
@@ -35,7 +35,7 @@ const API_ENDPOINT: &str = "https://api.noopschallenge.com/hexbot?";
 /// # use hexbot::*;
 /// let hb = Hexbot::fetch(
 ///     Count::yes(50)?,
-///     WithCoordinates::no(),
+///     WidthHeight::no(),
 ///     &Seed::no()
 /// )?;
 ///
@@ -77,37 +77,37 @@ impl Hexbot {
     /// // https://api.noopschallenge.com/hexbot?
     /// let hb1 = Hexbot::fetch(
     ///     Count::no(),
-    ///     WithCoordinates::no(),
+    ///     WidthHeight::no(),
     ///     &Seed::no()
     /// )?;
     /// // https://api.noopschallenge.com/hexbot?count=100
     /// let hb2 = Hexbot::fetch(
     ///     Count::yes(100)?,
-    ///     WithCoordinates::no(),
+    ///     WidthHeight::no(),
     ///     &Seed::no()
     /// )?;
     /// // https://api.noopschallenge.com/hexbot?&width=40&height=60
     /// let hb3 = Hexbot::fetch(
     ///     Count::no(),
-    ///     WithCoordinates::yes(CoordinatesLimit::new(40, 60)?),
+    ///     WidthHeight::yes(40, 60)?,
     ///     &Seed::no()
     /// )?;
     /// // https://api.noopschallenge.com/hexbot?&seed=B7410E,B22222
     /// let hb4 = Hexbot::fetch(
     ///     Count::no(),
-    ///     WithCoordinates::no(),
+    ///     WidthHeight::no(),
     ///     &Seed::new(&[0x_B7_41_0E, 0x_B2_22_22])?
     /// )?;
     /// // https://api.noopschallenge.com/hexbot?count=70&width=400&height=400
     /// let hb5 = Hexbot::fetch(
     ///     Count::yes(70)?,
-    ///     WithCoordinates::yes(CoordinatesLimit::new(400, 400)?),
+    ///     WidthHeight::yes(400, 400)?,
     ///     &Seed::no()
     /// )?;
     /// // https://api.noopschallenge.com/hexbot?count=1000&width=10&height=10
     /// let hb6 = Hexbot::fetch(
     ///     Count::max(),
-    ///     WithCoordinates::yes(CoordinatesLimit::min()),
+    ///     WidthHeight::min(),
     ///     &Seed::no()
     /// )?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -141,7 +141,7 @@ impl Hexbot {
     /// # use hexbot::*;
     /// let hb = Hexbot::fetch(
     ///     Count::yes(3)?,
-    ///     WithCoordinates::no(),
+    ///     WidthHeight::no(),
     ///     &Seed::new(&[0x_FF_FF_FF])?
     /// )
     /// .expect("Fetching failed");
@@ -164,7 +164,7 @@ impl Hexbot {
     /// # use hexbot::*;
     /// let hb = Hexbot::fetch(
     ///     Count::no(),
-    ///     WithCoordinates::no(),
+    ///     WidthHeight::no(),
     ///     &Seed::new(&[0x_AB_CD_EF])?
     /// )
     /// .expect("Fetching failed");
@@ -190,7 +190,7 @@ impl Hexbot {
     /// # use hexbot::*;
     /// let hexbot_with_coordinates = Hexbot::fetch(
     ///     Count::yes(6)?,
-    ///     WithCoordinates::yes(CoordinatesLimit::new(20, 20)?),
+    ///     WidthHeight::yes(20, 20)?,
     ///     &Seed::no()
     /// )
     /// .expect("Fetching failed");
@@ -198,7 +198,7 @@ impl Hexbot {
     ///
     /// let hexbot_without_coordinates = Hexbot::fetch(
     ///      Count::yes(6)?,
-    ///      WithCoordinates::no(),
+    ///      WidthHeight::no(),
     ///      &Seed::no()
     /// )
     /// .expect("Fetching failed");
@@ -217,7 +217,7 @@ impl Hexbot {
     /// # use hexbot::*;
     /// let hb = Hexbot::fetch(
     ///     Count::yes(5)?,
-    ///     WithCoordinates::no(),
+    ///     WidthHeight::no(),
     ///     &Seed::no()
     /// )
     /// .expect("Fetching failed");
@@ -225,7 +225,7 @@ impl Hexbot {
     ///
     /// let hb = Hexbot::fetch(
     ///     Count::no(),
-    ///     WithCoordinates::yes(CoordinatesLimit::new(500, 500)?),
+    ///     WidthHeight::yes(500, 500)?,
     ///     &Seed::no()
     /// )
     /// .expect("Fetching failed");
@@ -242,7 +242,7 @@ impl Hexbot {
     /// # use hexbot::*;
     /// let hb = Hexbot::fetch(
     ///     Count::yes(5)?,
-    ///     WithCoordinates::no(),
+    ///     WidthHeight::no(),
     ///     &Seed::new(&[0x_00_AA_00])?
     /// )
     /// .expect("Fetching failed");
@@ -258,7 +258,7 @@ impl Hexbot {
     /// # use hexbot::*;
     /// let hb = Hexbot::fetch(
     ///     Count::yes(5)?,
-    ///     WithCoordinates::no(),
+    ///     WidthHeight::no(),
     ///     &Seed::new(&[0x_00_AA_00])?
     /// )
     /// .expect("Fetching failed");
@@ -277,7 +277,7 @@ impl Hexbot {
     /// # use hexbot::*;
     /// let hexbot = Hexbot::fetch(
     ///     Count::yes(5)?,
-    ///     WithCoordinates::no(),
+    ///     WidthHeight::no(),
     ///     &Seed::new(&[0x_00_00_FF])?
     /// )
     /// .expect("Fetching failed");

--- a/src/hexbot/hexbot.rs
+++ b/src/hexbot/hexbot.rs
@@ -86,13 +86,13 @@ impl Hexbot {
     ///     WithCoordinates::no(),
     ///     &Seed::no()
     /// )?;
-    /// // https://api.noopschallenge.com/hexbot?width=40&height=60
+    /// // https://api.noopschallenge.com/hexbot?&width=40&height=60
     /// let hb3 = Hexbot::fetch(
     ///     Count::no(),
     ///     WithCoordinates::yes(CoordinatesLimit::new(40, 60)?),
     ///     &Seed::no()
     /// )?;
-    /// // https://api.noopschallenge.com/hexbot?seed=B7410E,B22222
+    /// // https://api.noopschallenge.com/hexbot?&seed=B7410E,B22222
     /// let hb4 = Hexbot::fetch(
     ///     Count::no(),
     ///     WithCoordinates::no(),
@@ -122,7 +122,7 @@ impl Hexbot {
     ) -> Result<Self, reqwest::Error> {
         let count = match count.get() {
             None => String::new(),
-            Some(count) => format!("&count={}", count),
+            Some(count) => format!("count={}", count),
         };
         let coordinates = match __WidthHeight::get(&coordinates) {
             None => String::new(),

--- a/src/hexbot/mod.rs
+++ b/src/hexbot/mod.rs
@@ -25,4 +25,5 @@ pub mod errors;
 #[allow(clippy::module_inception)]
 pub mod hexbot;
 pub mod seed;
+pub mod widthheight;
 pub mod withcoordinates;

--- a/src/hexbot/seed.rs
+++ b/src/hexbot/seed.rs
@@ -53,9 +53,8 @@ impl Seed {
     /// The error type [`SeedError`] has three types:
     ///  - [`SeedError::Empty`] occurs if `colors` is an empty slice.
     ///  - [`SeedError::ToLong`] occurs if `colors` has 11 or more elements.
-    ///  - [`SeedError::NoColor`] occurs if an element in `colors` isn't a valid color.
+    ///  - [`SeedError::NoColor(color)`] occurs if an element in `colors` isn't a valid color.
     ///    A valid color in a number between 0 (`0x_00_00_00`) and 16777215 (`0x_FF_FF_FF`).  
-    ///    **This variant will change in the future to `NoColor(i32)` which contains the bad
     ///    element.**
     ///
     /// ## Examples
@@ -89,7 +88,7 @@ impl Seed {
     /// [`SeedError`]: errors/enum.SeedError.html
     /// [`SeedError::Empty`]: errors/enum.SeedError.html#variant.Empty
     /// [`SeedError::ToLong`]: errors/enum.SeedError.html#variant.ToLong
-    /// [`SeedError::NoColor`]: errors/enum.SeedError.html#variant.NoColor
+    /// [`SeedError::NoColor(color)`]: errors/enum.SeedError.html#variant.NoColor
     pub fn new(colors: &[i32]) -> Result<Self, SeedError> {
         if colors.is_empty() {
             return Err(SeedError::Empty);
@@ -102,7 +101,7 @@ impl Seed {
             if 0x_00_00_00 <= *color && *color <= 0x_FF_FF_FF {
                 write!(&mut seed, "{:06X},", color).unwrap();
             } else {
-                return Err(SeedError::NoColor);
+                return Err(SeedError::NoColor(*color));
             }
         }
         seed.pop();
@@ -160,9 +159,8 @@ impl Seed {
     ///
     /// [`SeedError`] (same as [`new`]):
     ///  - [`SeedError::ToLong`] occurs if the seed already has 10 colors.
-    ///  - [`SeedError::NoColor`] occurs if `color` isn't a valid color.
+    ///  - [`SeedError::NoColor(color)`] occurs if `color` isn't a valid color.
     ///    A valid color in a number between 0 (`0x_00_00_00`) and 16777215 (`0x_FF_FF_FF`).  
-    ///    **This variant will change in the future to `NoColor(i32)`.**
     ///
     /// # Examples
     ///
@@ -196,10 +194,10 @@ impl Seed {
     /// [`new`]: #method.new
     /// [`SeedError`]: errors/enum.SeedError.html
     /// [`SeedError::ToLong`]: errors/enum.SeedError.html#variant.ToLong
-    /// [`SeedError::NoColor`]: errors/enum.SeedError.html#variant.NoColor
+    /// [`SeedError::NoColor(color)`]: errors/enum.SeedError.html#variant.NoColor
     pub fn add(&mut self, color: i32) -> Result<(), SeedError> {
         if color < 0x_00_00_00 || color > 0x_FF_FF_FF {
-            return Err(SeedError::NoColor);
+            return Err(SeedError::NoColor(color));
         }
         match self.0 {
             Some(ref mut seed) => write!(seed, ",{:06X}", color).unwrap(),

--- a/src/hexbot/seed.rs
+++ b/src/hexbot/seed.rs
@@ -29,14 +29,14 @@ use std::fmt::{self, Write};
 /// // Fetch a Hexbot with this seed: `00FFFF,0000FF,008B8B,00008B`.
 /// let hb = Hexbot::fetch(
 ///     Count::no(),
-///     WithCoordinates::no(),
+///     WidthHeight::no(),
 ///     &Seed::new(&[0x_00_FF_FF, 0x_00_00_FF, 0x_00_8B_8B, 0x_00_00_8B])?
 /// )?;
 ///
 /// // Don't add the `seed` parameter to the request.
 /// let hb = Hexbot::fetch(
 ///     Count::no(),
-///     WithCoordinates::no(),
+///     WidthHeight::no(),
 ///     &Seed::no()
 /// )?;
 /// # Ok::<(), Box<dyn std::error::Error>>(())

--- a/src/hexbot/widthheight.rs
+++ b/src/hexbot/widthheight.rs
@@ -1,0 +1,238 @@
+/*
+ * Copyright © 2019 rusty-snake <print_hello_world+License@protonmail.com>
+ *
+ * This file is part of rusty-snake's hexbot solution
+ *
+ * rusty-snake's hexbot solution is free software: you can redistribute
+ * it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * rusty-snake's hexbot solution is distributed in the hope that it
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::{errors::CoordinatesLimitOutOfRange, Coordinates};
+use std::{convert, fmt, ops};
+
+/// Representation of the `width` and `height` parameters of the [hexbot-API].
+///
+/// # Examples
+///
+/// ```no_run
+/// # use hexbot::*;
+/// let hb_with_coordinates = Hexbot::fetch(
+///     Count::no(),
+///     WidthHeight::yes(10_000, 2500)?,
+///     &Seed::no()
+/// )?;
+/// let hb_without_coordinates = Hexbot::fetch(
+///     Count::no(),
+///     WidthHeight::no(),
+///     &Seed::no()
+/// )?;
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// ```
+/// # use hexbot::*;
+/// use std::convert::TryFrom;
+/// let width_height = WidthHeight::try_from(
+///     Coordinates { x: 20, y: 20 }
+/// )?;
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// [hexbot-API]: https://github.com/noops-challenge/hexbot/blob/master/API.md
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Default)]
+pub struct WidthHeight(Option<Coordinates>);
+impl WidthHeight {
+    /// The minimum value for `width`/`height`.
+    ///
+    /// ```
+    /// # use hexbot::*;
+    /// assert_eq!(WidthHeight::MIN, 10);
+    /// ```
+    pub const MIN: i32 = 10;
+
+    /// The maximum value for `width`/`height`.
+    ///
+    /// ```
+    /// # use hexbot::*;
+    /// assert_eq!(WidthHeight::MAX, 100_000);
+    /// ```
+    pub const MAX: i32 = 100_000;
+
+    /// The allowed range for the value of `width`/`height`.
+    ///
+    /// ```
+    /// # use hexbot::*;
+    /// assert_eq!(
+    ///     WidthHeight::ALLOWED_RANGE,
+    ///     (WidthHeight::MIN..=WidthHeight::MAX)
+    /// );
+    /// ```
+    pub const ALLOWED_RANGE: ops::RangeInclusive<i32> = (Self::MIN..=Self::MAX);
+
+    /// Creates a new instance of `WidthHeight`.
+    ///
+    /// # Errors
+    ///
+    /// [`CoordinatesLimitOutOfRange`] occurs if `x` and/or `y` is not in [`ALLOWED_RANGE`].
+    ///
+    /// ## Examples
+    ///
+    /// ```should_panic
+    /// # use hexbot::*;
+    /// WidthHeight::yes(9, 40).unwrap();
+    /// ```
+    /// ```should_panic
+    /// # use hexbot::*;
+    /// WidthHeight::yes(100_001, 40).unwrap();
+    /// ```
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use hexbot::*;
+    /// let width_height = WidthHeight::yes(50, 80)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// [`ALLOWED_RANGE`]: #associatedconstant.ALLOWED_RANGE
+    /// [`CoordinatesLimitOutOfRange`]: errors/struct.CoordinatesLimitOutOfRange.html
+    pub fn yes(width: i32, height: i32) -> Result<Self, CoordinatesLimitOutOfRange> {
+        if Self::ALLOWED_RANGE.contains(&width) && Self::ALLOWED_RANGE.contains(&height) {
+            Ok(Self(Some(Coordinates {
+                x: width,
+                y: height,
+            })))
+        } else {
+            Err(CoordinatesLimitOutOfRange)
+        }
+    }
+
+    /// Creates a new empty instance of `WidthHeight`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use hexbot::*;
+    /// let width_height = WidthHeight::no();
+    /// ```
+    pub const fn no() -> Self {
+        Self(None)
+    }
+
+    /// Creates a new instance of `WidthHeight` with the highest possible values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use hexbot::*;
+    /// let max_width_height = WidthHeight::max();
+    /// assert_eq!(
+    ///     max_width_height,
+    ///     WidthHeight::yes(WidthHeight::MAX, WidthHeight::MAX)?
+    /// );
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub const fn max() -> Self {
+        Self(Some(Coordinates {
+            x: Self::MAX,
+            y: Self::MAX,
+        }))
+    }
+
+    /// Creates a new instance of `WidthHeight` with the lowest possible values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use hexbot::*;
+    /// let min_width_height = WidthHeight::min();
+    /// assert_eq!(
+    ///     min_width_height,
+    ///     WidthHeight::yes(WidthHeight::MIN, WidthHeight::MIN)?
+    /// );
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub const fn min() -> Self {
+        Self(Some(Coordinates {
+            x: Self::MIN,
+            y: Self::MIN,
+        }))
+    }
+
+    /// Returns `true` if this `WidthHeight` isn't empty, otherwise `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use hexbot::*;
+    /// assert_eq!(
+    ///     WidthHeight::yes(1024,1024)?.has(),
+    ///     true
+    /// );
+    /// assert_eq!(WidthHeight::no().has(), false);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn has(&self) -> bool {
+        self.0.is_some()
+    }
+
+    /// Returns a reference to the values of width and height.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use hexbot::*;
+    /// assert_eq!(
+    ///     WidthHeight::yes(25, 25)?.get(),
+    ///     &Some(Coordinates { x: 25, y: 25 })
+    /// );
+    /// assert_eq!(
+    ///     WidthHeight::min().get(),
+    ///     &Some(Coordinates {
+    ///         x: WidthHeight::MIN,
+    ///         y: WidthHeight::MIN,
+    ///     })
+    /// );
+    /// assert_eq!(
+    ///     WidthHeight::max().get(),
+    ///     &Some(Coordinates {
+    ///         x: WidthHeight::MAX,
+    ///         y: WidthHeight::MAX,
+    ///     })
+    /// );
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn get(&self) -> &Option<Coordinates> {
+        &self.0
+    }
+}
+impl fmt::Display for WidthHeight {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            Some(ref value) => write!(f, "width:{},height:{}", value.x, value.y),
+            None => write!(f, ""),
+        }
+    }
+}
+impl convert::TryFrom<Coordinates> for WidthHeight {
+    type Error = CoordinatesLimitOutOfRange;
+
+    fn try_from(coordinates: Coordinates) -> Result<Self, Self::Error> {
+        Self::yes(coordinates.x, coordinates.y)
+    }
+}
+impl crate::__WidthHeight for WidthHeight {
+    fn get(&self) -> Option<Coordinates> {
+        *self.get()
+    }
+}

--- a/src/hexbot/withcoordinates.rs
+++ b/src/hexbot/withcoordinates.rs
@@ -17,6 +17,10 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+#![deprecated(since = "0.0.11", note = "Use WidthHeight instead.")]
+// Don't warn about CoordinatesLimit
+#![allow(deprecated)]
+
 use crate::{Coordinates, CoordinatesLimit};
 use std::fmt;
 

--- a/src/hexbot/withcoordinates.rs
+++ b/src/hexbot/withcoordinates.rs
@@ -17,7 +17,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use crate::CoordinatesLimit;
+use crate::{Coordinates, CoordinatesLimit};
 use std::fmt;
 
 /// Abstract representation of the `width` and the `height` parameter of the [hexbot-API].
@@ -113,5 +113,10 @@ impl fmt::Display for WithCoordinates {
             Some(limit) => write!(f, "{}", limit),
             None => write!(f, ""),
         }
+    }
+}
+impl crate::__WidthHeight for WithCoordinates {
+    fn get(&self) -> Option<Coordinates> {
+        Some(*(*self.limit())?.get())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,4 +111,17 @@ pub use crate::hexbot::{
     hexbot::Hexbot,
     seed::Seed,
     withcoordinates::WithCoordinates,
+    widthheight::WidthHeight,
 };
+
+#[doc(hidden)]
+pub trait __WidthHeight: private::Sealed {
+    fn get(&self) -> Option<Coordinates>;
+}
+
+#[allow(deprecated)]
+mod private {
+    pub trait Sealed {}
+    impl Sealed for crate::WidthHeight {}
+    impl Sealed for crate::WithCoordinates {}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,8 @@ mod hexbot;
 
 pub use tint::Color;
 #[rustfmt::skip]
+// Don't warn about CoordinatesLimit and WithCoordinates
+#[allow(deprecated)]
 pub use crate::hexbot::{
     coordinates::Coordinates,
     coordinateslimit::CoordinatesLimit,

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use hexbot::{CoordinatesLimit, Count, Hexbot, Seed, WithCoordinates};
+use hexbot::{Count, Hexbot, Seed, WidthHeight};
 use std::io;
 use std::io::Write;
 
@@ -66,18 +66,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let with_coordinates =
         if ask_bool("Should the width and height parameters be added? [yes|no] ")? {
-            WithCoordinates::yes(loop {
-                if let Ok(limit) = CoordinatesLimit::new(
+            loop {
+                match WidthHeight::yes(
                     ask_i32("What value should width have? [10-100,000] ")?,
                     ask_i32("What value should height have? [10-100,000] ")?,
                 ) {
-                    break limit;
-                } else {
-                    println!("This is a invalid width/height, try again.");
+                    Ok(limit) => break limit,
+                    Err(_) => println!("This is a invalid width/height, try again."),
                 }
-            })
+            }
         } else {
-            WithCoordinates::no()
+            WidthHeight::no()
         };
     let hb = Hexbot::fetch(count, with_coordinates, &Seed::no()).expect("Fetching failed");
     println!("{}", hb);


### PR DESCRIPTION
 ## [0.0.11] - 2019-10-13
 ### Added
  * `Seed::add`
  * impl ops::{Add,Sub} for Coordinates
  * `hexbot::WidthHeight` improved replacement for `WithCoordinates` and `CoordinatesLimit`

 ### Changed
  * `Hexbot::fetch` accept both `WithCoordinates` and `WidthHeight`
  * old:`SeedError::NoColor` new:`SeedError::NoColor(i32)`

 ### Deprecated
  * `WithCoordinates` use `WidthHeight`
  * `CoordinatesLimit` use `WidthHeight`

 [0.0.11]: https://github.com/rusty-snake/hexbot/tree/v0.0.11