### PR TITLE
Update .travic.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 cache: cargo
+os: linux
 dist: bionic
-sudo: false
 rust:
   - 1.37.0
   - stable


### PR DESCRIPTION
- `sudo` is deprecated and ignored
- explicit `os`